### PR TITLE
Move to 'http' package

### DIFF
--- a/lib/rollbar.dart
+++ b/lib/rollbar.dart
@@ -2,10 +2,10 @@ library rollbar;
 
 import 'dart:async';
 import 'dart:convert';
-import 'dart:html';
 import 'package:logging/logging.dart';
 import 'package:stack_trace/stack_trace.dart';
 import 'package:rollbar/src/map_util.dart';
+import 'package:http/http.dart';
 
 part 'src/rollbar_client.dart';
 part 'src/rollbar_request.dart';

--- a/lib/src/rollbar_request.dart
+++ b/lib/src/rollbar_request.dart
@@ -4,18 +4,19 @@ class RollbarRequest {
   String _accessToken;
   Map<String, Object> _data;
   Logger _logger;
+  Client _client;
 
-  RollbarRequest(this._accessToken, this._data, this._logger);
+  RollbarRequest(this._accessToken, this._data, this._logger, this._client);
 
   Future<Response> send() {
     var json = JSON.encode({"access_token": _accessToken, "data": _data});
 
-    var request = post("https://api.rollbar.com/api/1/item/",
+    var request = _client.post("https://api.rollbar.com/api/1/item/",
         headers: {"Content-Type": "application/json"},
         body: json);
 
     return request
-        ..then((request) => _logStatus(request))
+        ..then((response) => _logStatus(response))
         ..catchError((error) => _logError(error));
   }
 

--- a/lib/src/rollbar_request.dart
+++ b/lib/src/rollbar_request.dart
@@ -7,21 +7,20 @@ class RollbarRequest {
 
   RollbarRequest(this._accessToken, this._data, this._logger);
 
-  Future<HttpRequest> send() {
+  Future<Response> send() {
     var json = JSON.encode({"access_token": _accessToken, "data": _data});
 
-    var request = HttpRequest.request("https://api.rollbar.com/api/1/item/",
-        method: "POST",
-        requestHeaders: {"Content-Type": "application/json"},
-        sendData: json);
+    var request = post("https://api.rollbar.com/api/1/item/",
+        headers: {"Content-Type": "application/json"},
+        body: json);
 
     return request
         ..then((request) => _logStatus(request))
         ..catchError((error) => _logError(error));
   }
 
-  void _logStatus(HttpRequest request) {
-    switch(request.status) {
+  void _logStatus(Response response) {
+    switch(response.statusCode) {
       case 200:
         _logger.finer("Success. The item was accepted for processing.");
         break;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,4 +8,4 @@ homepage: http://www.github.com/Mixbook/rollbar.dart
 dependencies:
   stack_trace: '>=1.0.2 <2.0.0'
   logging: '>=0.9.1 <0.10.0'
-  http: any
+  http: '>=0.11.1'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: rollbar
-version: 0.2.0
+version: 0.3.0
 authors:
   - Anton Astashov <anton.astashov@gmail.com>
   - Dan Schultz <schultz.t.dan@gmail.com>
@@ -8,3 +8,4 @@ homepage: http://www.github.com/Mixbook/rollbar.dart
 dependencies:
   stack_trace: '>=1.0.2 <2.0.0'
   logging: '>=0.9.1 <0.10.0'
+  http: any


### PR DESCRIPTION
That will allow to get rid of 'dart:html' import, so we could use
rollbar.dart both on the client and the server.

@danschultz PTAL